### PR TITLE
Sum of pairwise Hamming Distance

### DIFF
--- a/Coding/InterviewBit/Sum_of_pairwise_Hamming_Distance.cpp
+++ b/Coding/InterviewBit/Sum_of_pairwise_Hamming_Distance.cpp
@@ -1,0 +1,24 @@
+
+#define mod 1000000007
+
+int Solution::hammingDistance(const vector<int> &A) {
+    
+    long long int ans = 0;  // Initialize result
+     int n   = A.size();
+ 
+    // traverse over all bits
+    for (int i = 0; i < 32; i++)
+    {
+        // count number of elements with i'th bit set
+        int count = 0;
+        for (int j = 0; j < n; j++)
+            if ( (A[j] & (1 << i)) )
+                count++;
+ 
+        // Add "count * (n - count) * 2" to the answer
+        ans = ( ans % mod + (count % mod *1ll* (n - count) % mod *1ll* 2 % mod) %mod ) % mod;
+    }
+ 
+    return ans % mod;
+}
+


### PR DESCRIPTION
#InterviewBit Math Section
Hamming distance between two non-negative integers is defined as the number of positions at which the corresponding bits are different.

For example,

HammingDistance(2, 7) = 2, as only the first and the third bit differs in the binary representation of 2 (010) and 7 (111).

Given an array of N non-negative integers, find the sum of hamming distances of all pairs of integers in the array.
Return the answer modulo 1000000007.
